### PR TITLE
Fix/integrate spring security with existing user

### DIFF
--- a/PlatePlanner/src/main/java/org/launchcode/PlatePlanner/config/SecurityConfig.java
+++ b/PlatePlanner/src/main/java/org/launchcode/PlatePlanner/config/SecurityConfig.java
@@ -1,7 +1,11 @@
 package org.launchcode.PlatePlanner.config;
 
+import org.launchcode.PlatePlanner.service.CustomUserDetailsService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -18,6 +22,12 @@ import java.util.Arrays;
 @EnableMethodSecurity
 public class SecurityConfig {
 
+    private final CustomUserDetailsService customUserDetailsService;
+
+    public SecurityConfig(CustomUserDetailsService customUserDetailsService) {
+        this.customUserDetailsService = customUserDetailsService;
+    }
+
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         return http
@@ -30,6 +40,14 @@ public class SecurityConfig {
                 .logout(config -> config.logoutSuccessUrl("http://localhost:8080/secure-access/process-logout"))
                 .build();
 
+    }
+
+    @Bean
+    public DaoAuthenticationProvider authenticationProvider() {
+        DaoAuthenticationProvider authProvider = new DaoAuthenticationProvider();
+        authProvider.setUserDetailsService(customUserDetailsService);
+        authProvider.setPasswordEncoder(passwordEncoder());
+        return authProvider;
     }
 
     @Bean
@@ -46,6 +64,11 @@ public class SecurityConfig {
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);
         return source;
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
     }
 
 }

--- a/PlatePlanner/src/main/java/org/launchcode/PlatePlanner/controllers/AccountController.java
+++ b/PlatePlanner/src/main/java/org/launchcode/PlatePlanner/controllers/AccountController.java
@@ -80,7 +80,7 @@ public class AccountController {
             newUser.setEmail(registerDto.getEmail());
             newUser.setPhone(registerDto.getPhone());
             newUser.setAddress(registerDto.getAddress());
-            newUser.setUsername(registerDto.getUserName());
+            newUser.setUsername(registerDto.getUsername());
 
             newUser.setRole(Role.USER);
             newUser.setPassword(bCryptEncoder.encode(registerDto.getPassword()));

--- a/PlatePlanner/src/main/java/org/launchcode/PlatePlanner/controllers/AccountController.java
+++ b/PlatePlanner/src/main/java/org/launchcode/PlatePlanner/controllers/AccountController.java
@@ -1,9 +1,10 @@
 package org.launchcode.PlatePlanner.controllers;
 
 import jakarta.validation.Valid;
-import org.launchcode.PlatePlanner.model.AppUser;
 import org.launchcode.PlatePlanner.model.RegisterDto;
-import org.launchcode.PlatePlanner.repository.AppUserRepository;
+import org.launchcode.PlatePlanner.model.Role;
+import org.launchcode.PlatePlanner.model.User;
+import org.launchcode.PlatePlanner.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -15,16 +16,16 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 
-import java.util.Date;
+import java.util.Optional;
 
 @Controller
 public class AccountController {
     @Autowired
-    private AppUserRepository repo;
+    private UserRepository userRepository;
 
     @GetMapping("/profile")
     public String profile(Authentication auth, Model model) {
-        AppUser user = repo.findByEmail(auth.getName());
+        Optional<User> user = userRepository.findByEmail(auth.getName());
         model.addAttribute("appUser", user);
 
         return "profile";
@@ -57,8 +58,8 @@ public class AccountController {
             );
         }
 
-        AppUser appUser = repo.findByEmail(registerDto.getEmail());
-        if (appUser != null) {
+        Optional<User> user = userRepository.findByEmail(registerDto.getEmail());
+        if (user.isPresent()) {
             result.addError(
                     new FieldError("registerDto", "email"
                             , "Email address is already used")
@@ -73,18 +74,18 @@ public class AccountController {
 
             var bCryptEncoder = new BCryptPasswordEncoder();
 
-            AppUser newUser = new AppUser();
+            User newUser = new User();
             newUser.setFirstName(registerDto.getFirstName());
             newUser.setLastName(registerDto.getLastName());
             newUser.setEmail(registerDto.getEmail());
             newUser.setPhone(registerDto.getPhone());
             newUser.setAddress(registerDto.getAddress());
+            newUser.setUsername(registerDto.getUserName());
 
-            newUser.setRole("user");
-            newUser.setCreatedAt(new Date());
+            newUser.setRole(Role.USER);
             newUser.setPassword(bCryptEncoder.encode(registerDto.getPassword()));
 
-            repo.save(newUser);
+            userRepository.save(newUser);
 
             model.addAttribute("registerDto", new RegisterDto());
             model.addAttribute("success", true);

--- a/PlatePlanner/src/main/java/org/launchcode/PlatePlanner/model/AppUser.java
+++ b/PlatePlanner/src/main/java/org/launchcode/PlatePlanner/model/AppUser.java
@@ -1,83 +1,83 @@
-package org.launchcode.PlatePlanner.model;
-
-import java.util.Date;
-
-import jakarta.persistence.*;
-
-@Entity
-@Table(name="users")
-public class AppUser {
-
-    @Id
-    @GeneratedValue(strategy=GenerationType.IDENTITY)
-    private int id;
-
-    private String firstName;
-    private String lastName;
-
-    @Column(unique = true, nullable = false)
-    private String email;
-
-    private String phone;
-    private String address;
-    private String password;
-    private String role;
-    private Date createdAt;
-
-    public int getId() {
-        return id;
-    }
-    public void setId(int id) {
-        this.id = id;
-    }
-    public String getFirstName() {
-        return firstName;
-    }
-    public void setFirstName(String firstName) {
-        this.firstName = firstName;
-    }
-    public String getLastName() {
-        return lastName;
-    }
-    public void setLastName(String lastName) {
-        this.lastName = lastName;
-    }
-    public String getEmail() {
-        return email;
-    }
-    public void setEmail(String email) {
-        this.email = email;
-    }
-    public String getPhone() {
-        return phone;
-    }
-    public void setPhone(String phone) {
-        this.phone = phone;
-    }
-    public String getAddress() {
-        return address;
-    }
-    public void setAddress(String address) {
-        this.address = address;
-    }
-    public String getPassword() {
-        return password;
-    }
-    public void setPassword(String password) {
-        this.password = password;
-    }
-    public String getRole() {
-        return role;
-    }
-
-    public void setRole(String role) {
-        this.role = role;
-    }
-    public Date getCreatedAt() {
-        return createdAt;
-    }
-    public void setCreatedAt(Date createdAt) {
-        this.createdAt = createdAt;
-    }
-}
-
+//package org.launchcode.PlatePlanner.model;
+//
+//import java.util.Date;
+//
+//import jakarta.persistence.*;
+//
+//@Entity
+//@Table(name="users")
+//public class AppUser {
+//
+//    @Id
+//    @GeneratedValue(strategy=GenerationType.IDENTITY)
+//    private int id;
+//
+//    private String firstName;
+//    private String lastName;
+//
+//    @Column(unique = true, nullable = false)
+//    private String email;
+//
+//    private String phone;
+//    private String address;
+//    private String password;
+//    private String role;
+//    private Date createdAt;
+//
+//    public int getId() {
+//        return id;
+//    }
+//    public void setId(int id) {
+//        this.id = id;
+//    }
+//    public String getFirstName() {
+//        return firstName;
+//    }
+//    public void setFirstName(String firstName) {
+//        this.firstName = firstName;
+//    }
+//    public String getLastName() {
+//        return lastName;
+//    }
+//    public void setLastName(String lastName) {
+//        this.lastName = lastName;
+//    }
+//    public String getEmail() {
+//        return email;
+//    }
+//    public void setEmail(String email) {
+//        this.email = email;
+//    }
+//    public String getPhone() {
+//        return phone;
+//    }
+//    public void setPhone(String phone) {
+//        this.phone = phone;
+//    }
+//    public String getAddress() {
+//        return address;
+//    }
+//    public void setAddress(String address) {
+//        this.address = address;
+//    }
+//    public String getPassword() {
+//        return password;
+//    }
+//    public void setPassword(String password) {
+//        this.password = password;
+//    }
+//    public String getRole() {
+//        return role;
+//    }
+//
+//    public void setRole(String role) {
+//        this.role = role;
+//    }
+//    public Date getCreatedAt() {
+//        return createdAt;
+//    }
+//    public void setCreatedAt(Date createdAt) {
+//        this.createdAt = createdAt;
+//    }
+//}
+//

--- a/PlatePlanner/src/main/java/org/launchcode/PlatePlanner/model/RegisterDto.java
+++ b/PlatePlanner/src/main/java/org/launchcode/PlatePlanner/model/RegisterDto.java
@@ -13,14 +13,15 @@ public class RegisterDto {
     private  String lastName;
 
     @NotEmpty
-    private String userName;
+    private String username;
 
-    public String getUserName() {
-        return userName;
+    @NotEmpty
+    public String getUsername() {
+        return username;
     }
 
-    public void setUserName(String userName) {
-        this.userName = userName;
+    public void setUsername(String username) {
+        this.username = username;
     }
 
     public String getFirstName() {

--- a/PlatePlanner/src/main/java/org/launchcode/PlatePlanner/model/RegisterDto.java
+++ b/PlatePlanner/src/main/java/org/launchcode/PlatePlanner/model/RegisterDto.java
@@ -12,6 +12,17 @@ public class RegisterDto {
     @NotEmpty
     private  String lastName;
 
+    @NotEmpty
+    private String userName;
+
+    public String getUserName() {
+        return userName;
+    }
+
+    public void setUserName(String userName) {
+        this.userName = userName;
+    }
+
     public String getFirstName() {
         return firstName;
     }

--- a/PlatePlanner/src/main/java/org/launchcode/PlatePlanner/model/User.java
+++ b/PlatePlanner/src/main/java/org/launchcode/PlatePlanner/model/User.java
@@ -5,12 +5,18 @@ import jakarta.persistence.*;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotNull;
 import org.hibernate.validator.constraints.Length;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
 import java.time.LocalDateTime;
+import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 @Entity
-public class User extends AbstractEntity {
+public class User extends AbstractEntity implements UserDetails {
 
     @NotNull
     @Length(max = 25, message = "Username cannot exceed 25 characters.")
@@ -33,6 +39,14 @@ public class User extends AbstractEntity {
     @NotNull
     private LocalDateTime createdAt;
 
+    @NotNull
+    private boolean enabled;
+
+    private String firstName;
+    private String lastName;
+    private String phone;
+    private String address;
+
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     @JsonIgnoreProperties({"user"})
     private Set<MealPlan> mealPlans = new HashSet<>();
@@ -45,12 +59,6 @@ public class User extends AbstractEntity {
 
     public User() {}
 
-//    James will update this:
-//    public User() {
-//        super();
-//        ;
-//    }
-
     public User(String username, String password, String email, Role role) {
         this.username = username;
         this.password = password;
@@ -61,19 +69,14 @@ public class User extends AbstractEntity {
     @PrePersist
     public void onCreate() {
         this.createdAt = LocalDateTime.now();
-        this.role = Role.USER;
-    }
-
-    public String getUsername() {
-        return username;
+        if (this.role == null) {
+            this.role = Role.USER;
+        }
+        this.enabled = true;
     }
 
     public void setUsername(String username) {
         this.username = username;
-    }
-
-    public String getPassword() {
-        return password;
     }
 
     public void setPassword(String password) {
@@ -154,8 +157,63 @@ public class User extends AbstractEntity {
         shoppingLists.remove(shoppingList);
     }
 
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public String getPhone() {
+        return phone;
+    }
+
+    public void setPhone(String phone) {
+        this.phone = phone;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
     @Override
     public String toString() {
         return "Username: " + this.username + " | User ID: " + this.getId();
     }
+
+    //UserDetails Implementations:
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority("ROLE_" + this.role.name()));
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public String getUsername() {
+        return username;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return enabled;
+    }
+
 }

--- a/PlatePlanner/src/main/java/org/launchcode/PlatePlanner/repository/AppUserRepository.java
+++ b/PlatePlanner/src/main/java/org/launchcode/PlatePlanner/repository/AppUserRepository.java
@@ -1,9 +1,9 @@
-package org.launchcode.PlatePlanner.repository;
-
-import org.launchcode.PlatePlanner.model.AppUser;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface AppUserRepository extends JpaRepository<AppUser, Integer> {
-
-    public AppUser findByEmail (String email);
-}
+//package org.launchcode.PlatePlanner.repository;
+//
+//import org.launchcode.PlatePlanner.model.AppUser;
+//import org.springframework.data.jpa.repository.JpaRepository;
+//
+//public interface AppUserRepository extends JpaRepository<AppUser, Integer> {
+//
+//    public AppUser findByEmail (String email);
+//}

--- a/PlatePlanner/src/main/java/org/launchcode/PlatePlanner/repository/UserRepository.java
+++ b/PlatePlanner/src/main/java/org/launchcode/PlatePlanner/repository/UserRepository.java
@@ -5,6 +5,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByEmail(String email);
+
 }

--- a/PlatePlanner/src/main/java/org/launchcode/PlatePlanner/service/AppUserService.java
+++ b/PlatePlanner/src/main/java/org/launchcode/PlatePlanner/service/AppUserService.java
@@ -1,32 +1,32 @@
-package org.launchcode.PlatePlanner.service;
-
-import org.launchcode.PlatePlanner.model.AppUser;
-import org.launchcode.PlatePlanner.repository.AppUserRepository;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.core.userdetails.User;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
-import org.springframework.stereotype.Service;
-
-@Service
-public class AppUserService implements UserDetailsService {
-    @Autowired
-    private AppUserRepository repo;
-
-    @Override
-    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-        AppUser appUser = repo.findByEmail(email);
-
-        if (appUser != null) {
-            var springUser = User.withUsername(appUser.getEmail())
-                    .password(appUser.getPassword())
-                    .roles(appUser.getRole())
-                    .build();
-            return springUser;
-        }
-
-        return null;
-    }
-}
-
+//package org.launchcode.PlatePlanner.service;
+//
+//import org.launchcode.PlatePlanner.model.AppUser;
+//import org.launchcode.PlatePlanner.repository.AppUserRepository;
+//import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.security.core.userdetails.User;
+//import org.springframework.security.core.userdetails.UserDetails;
+//import org.springframework.security.core.userdetails.UserDetailsService;
+//import org.springframework.security.core.userdetails.UsernameNotFoundException;
+//import org.springframework.stereotype.Service;
+//
+//@Service
+//public class AppUserService implements UserDetailsService {
+//    @Autowired
+//    private AppUserRepository repo;
+//
+//    @Override
+//    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+//        AppUser appUser = repo.findByEmail(email);
+//
+//        if (appUser != null) {
+//            var springUser = User.withUsername(appUser.getEmail())
+//                    .password(appUser.getPassword())
+//                    .roles(appUser.getRole())
+//                    .build();
+//            return springUser;
+//        }
+//
+//        return null;
+//    }
+//}
+//

--- a/PlatePlanner/src/main/java/org/launchcode/PlatePlanner/service/CustomUserDetailsService.java
+++ b/PlatePlanner/src/main/java/org/launchcode/PlatePlanner/service/CustomUserDetailsService.java
@@ -1,0 +1,26 @@
+package org.launchcode.PlatePlanner.service;
+
+import org.launchcode.PlatePlanner.model.User;
+import org.launchcode.PlatePlanner.repository.UserRepository;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    public CustomUserDetailsService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found with email: " + email));
+
+        return user;
+    }
+}

--- a/PlatePlanner/src/main/resources/templates/register.html
+++ b/PlatePlanner/src/main/resources/templates/register.html
@@ -22,6 +22,12 @@
                 <input type="hidden" th:name="${_csrf.parameterName}"
                        th:value="${_csrf.token}" />
                 <div class="row mb-3">
+                    <label class="col-sm-4 col-form-label">Username*</label>
+                    <div class="col-sm-8">
+                        <input class="form-control" th:field="${registerDto.userName}">
+                    </div>
+                </div>
+                <div class="row mb-3">
                     <label class="col-sm-4 col-form-label">First Name*</label>
                     <div class="col-sm-8">
                         <input class="form-control" th:field="${registerDto.firstName}">


### PR DESCRIPTION
Hey team,

I've refactored some of the Spring Security and User classes so that we now only have the one User table.

Here's an overview of what I needed to change to accommodate this:

- New CustomUserDetailsService class. This class is a custom implementation of Spring Security's UserDetailsService interface. It is responsible for retrieving user information (based on a given email) from the database and providing it to Spring Security for authentication purposes.
- SecurityConfig changes include implementing the CustomUserDetailsService and adding two methods that integrate the Spring Security authentication system with the new CustomUserDetailsService
- Refactored AccountController so that it calls the methods from User rather than AppUser
- Commented out AppUser, AppUserRepository, and AppUserService to remove redundancy
- Refactored the User entity so that it included the fields needed for the registration and login. This class now implements UserDetails, which enables the User entity to act as the bridge between your database and Spring Security's authentication system. Some of those methods have been overridden.
- Updated the registration form to accept a username.

Now we should be good to use all our other controller methods that rely on the user table and we still maintain the relationships between users and their recipes/mealplans/shoppinglists/etc.

DW