### PR TITLE
Removed hidden _csrf inputs.  Fixed lookup of user by using e-mail in…

### DIFF
--- a/PlatePlanner/src/main/java/org/launchcode/PlatePlanner/controllers/AccountController.java
+++ b/PlatePlanner/src/main/java/org/launchcode/PlatePlanner/controllers/AccountController.java
@@ -25,7 +25,8 @@ public class AccountController {
 
     @GetMapping("/profile")
     public String profile(Authentication auth, Model model) {
-        Optional<User> user = userRepository.findByEmail(auth.getName());
+        Optional<User> optUser = userRepository.findByEmail(((User) auth.getPrincipal()).getEmail());
+        User user = optUser.get();
         model.addAttribute("appUser", user);
 
         return "profile";

--- a/PlatePlanner/src/main/resources/templates/index.html
+++ b/PlatePlanner/src/main/resources/templates/index.html
@@ -52,8 +52,6 @@
             </ul>
 
             <form sec:authorize="isAuthenticated()" method="post" action="/logout">
-                <input type="hidden" th:name="${_csrf.parameterName}"
-                       th:value="${_csrf.token}" />
 
                 <button type="submit" class="btn btn-danger">
                     Logout

--- a/PlatePlanner/src/main/resources/templates/login.html
+++ b/PlatePlanner/src/main/resources/templates/login.html
@@ -19,8 +19,6 @@
                     aria-label="Close"></button>
         </div>
         <form method="post">
-            <input type="hidden" th:name="${_csrf.parameterName}"
-                   th:value="${_csrf.token}" />
             <div class="mb-3">
                 <label class="form-label">Email</label>
                 <input class="form-control" name="email" />

--- a/PlatePlanner/src/main/resources/templates/register.html
+++ b/PlatePlanner/src/main/resources/templates/register.html
@@ -19,12 +19,10 @@
                         aria-label="Close"></button>
             </div>
             <form method="post" th:object="${registerDto}">
-                <input type="hidden" th:name="${_csrf.parameterName}"
-                       th:value="${_csrf.token}" />
                 <div class="row mb-3">
                     <label class="col-sm-4 col-form-label">Username*</label>
                     <div class="col-sm-8">
-                        <input class="form-control" th:field="${registerDto.userName}">
+                        <input class="form-control" th:field="${registerDto.username}">
                     </div>
                 </div>
                 <div class="row mb-3">


### PR DESCRIPTION
…stead of name.

The hidden _csrf input fields are no longer needed since we have removed CSRF and were causing null pointer errors.
The account controller class was trying to look up a user by e-mail using a name instead of e-mail.