### PR TITLE
Filter saved recipes by tag, add ad-hoc tags

### DIFF
--- a/PlatePlanner/src/main/java/org/launchcode/PlatePlanner/model/Recipe.java
+++ b/PlatePlanner/src/main/java/org/launchcode/PlatePlanner/model/Recipe.java
@@ -26,6 +26,7 @@ public class Recipe extends AbstractEntity {
     private Set<User> user = new HashSet<>();
 
     @OneToMany(mappedBy = "recipe", cascade = CascadeType.ALL, orphanRemoval = true)
+    @JsonIgnore
     private List<MealPlanRecipe> mealPlanRecipes = new ArrayList<>();
 
     @NotNull

--- a/plate-planner-react/package-lock.json
+++ b/plate-planner-react/package-lock.json
@@ -12,6 +12,7 @@
         "bootstrap": "^5.3.3",
         "js-cookie": "^3.0.5",
         "mdb-react-ui-kit": "^9.0.0",
+        "prop-types": "^15.8.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^7.1.1"
@@ -3353,7 +3354,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3585,7 +3585,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -3637,8 +3636,7 @@
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/react-popper": {
       "version": "2.3.0",

--- a/plate-planner-react/package.json
+++ b/plate-planner-react/package.json
@@ -13,10 +13,11 @@
     "axios": "^1.7.9",
     "bootstrap": "^5.3.3",
     "js-cookie": "^3.0.5",
+    "mdb-react-ui-kit": "^9.0.0",
+    "prop-types": "^15.8.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^7.1.1",
-    "mdb-react-ui-kit": "^9.0.0"
+    "react-router-dom": "^7.1.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.15.0",

--- a/plate-planner-react/src/components/RecipeAddTag.jsx
+++ b/plate-planner-react/src/components/RecipeAddTag.jsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import React, {useState} from 'react';
+import PropTypes from "prop-types";
 import {
   MDBBtn,
   MDBModal,
@@ -7,151 +8,198 @@ import {
   MDBModalHeader,
   MDBModalTitle,
   MDBModalBody,
-  MDBModalFooter,
+  MDBModalFooter, MDBInput,
 } from 'mdb-react-ui-kit';
 import Button from "./Button";
 import recipeService from "../services/recipeService.js";
 import tagService from "../services/tagService.js";
+// this will tell the component what props (and what the types are) so intellij doesn't freak out!
+App.propTypes = {
+  recipe: PropTypes.object,
+  stateCounter: PropTypes.number,
+  setStateCounter: PropTypes.func,
+};
+export default function App({recipe, setStateCounter, stateCounter}) {
+  const [basicModal, setBasicModal] = useState(false);
+  const [tags, setTags] = useState([]);
+  const [tagsToSave, setTagsToSave] = useState([]);
+  const [tagIdsToSave, setTagIdsToSave] = useState([]);
+  const [actionMsg, setActionMsg] = useState(null);
+  const [tagToCreate, setTagToCreate] = useState(null);
 
+  const toggleOpen = () => {
+    setBasicModal(!basicModal);
+    loadTags();
+    setActionMsg(null);
+    setTagsToSave([]);
+  }
 
-export default function App(props) {
-    const [basicModal, setBasicModal] = useState(false);
-    const [recipeToTag, setRecipeToTag] = useState(props.recipe);
-    const [tags, setTags] = useState(null);
-    const [tagsToSave, setTagsToSave] = useState(null);
-    const [tagIdsToSave, setTagIdsToSave] = useState(null);
-    const [actionMsg, setActionMsg] = useState(null);
+  const closeWindow = () => {
+    setTags([]);
+    setStateCounter(stateCounter + 1);
+    toggleOpen();
+  }
 
-
-    const toggleOpen = () => {
-        setBasicModal(!basicModal);
-        loadTags();
+  const loadTags = () => {
+    setActionMsg("Loading Tags...");
+    tagService.getAll()
+      .then((response) => {
+        setTags(response.data);
         setActionMsg(null);
-        setTagsToSave(null);
+        // console.log("response.data: ", response.data);
+      })
+      .catch((err) => {
+        setActionMsg("There was a problem connecting to the database.  Please try again later.");
+        console.log("Error: ", err.message);
+      });
+
+  }
+
+  const handleTagSelect = (e) => {
+    let chosenTags = [];
+    let chosenTagIds = [];
+    for (var i = 0; i < e.target.options.length; i++) {
+      // console.log("Option: ", e.target.options[i])
+      if (e.target.options[i].selected) {
+        chosenTags.push(tags[i]);
+        chosenTagIds.push(tags[i].id);
+      }
     }
 
-    const closeWindow = () => {
-        setTags(null);
-        props.setStateCounter(props.counter + 1);
-        toggleOpen();
+    setTagsToSave(chosenTags);
+    setTagIdsToSave(chosenTagIds);
+    // console.log("chosenTags: ", chosenTags);
+    // console.log("chosenTagIds: ", chosenTagIds);
+  }
+
+  const createNewTag = () => {
+    setActionMsg("Creating new tag...");
+
+    if (tagToCreate) {
+      const tagObject = {
+        name: tagToCreate,
+        description: tagToCreate
+      }
+      tagService.create(tagObject)
+        .then(() => {
+          setActionMsg("New tag created.");
+          setTags([]);
+          loadTags();
+          setActionMsg(null);
+        })
+        .finally(() => {
+          setStateCounter(stateCounter + 1);
+        })
+        .catch((err) => {
+          setActionMsg("There was a problem connecting to the database.  Please try again later.");
+          console.log("Error: ", err.message);
+        });
     }
 
-    const loadTags = () => {
-        if (tags == null) {
-            setActionMsg("Loading Tags...");
-            tagService.getAll()
-                .then((response) => {
-                    setTags(response.data);
-                    setActionMsg(null);
-                    console.log("response.data: ", response.data);
-                })
-                .catch((err) => {
-                    setActionMsg("There was a problem connecting to the database.  Please try again later.");
-                    console.log("Error: ", err.message);
-                });
-        }
+  }
+
+  const updateRecipe = () => {
+    setActionMsg("Updating recipe with tags...");
+
+    if ((tagIdsToSave == null || tagIdsToSave.length === 0) && (recipe.tags == null || recipe.tags.length === 0)) {
+      setActionMsg("Please select one or more tags before clicking Update Tags.");
+      setTimeout(() => {
+        setActionMsg(null);
+      }, 3000);
+    } else {
+      if ((tagIdsToSave == null || tagIdsToSave.length === 0) && recipe.tags != null && recipe.tags.length > 0) {
+        setActionMsg("Removing tags from recipe.");
+        setTagIdsToSave([]);
+      }
+      recipeService.updateTagsToRecipe(recipe.id, tagIdsToSave)
+        .then(() => {
+          if (tagIdsToSave.length > 0) {
+            setActionMsg("Tags updated on recipe.");
+            recipe.tags = tagsToSave;
+            // console.log("recipe: ", recipe);
+          } else {
+            setActionMsg("Tags removed from recipe.");
+            recipe.tags = [];
+          }
+        })
+        .finally(() => {
+          setStateCounter(stateCounter + 1);
+        })
+        .catch((err) => {
+          setActionMsg("There was a problem connecting to the database.  Please try again later.");
+          console.log("Error: ", err.message);
+        });
     }
 
-    const handleTagSelect = (e) => {
-        let chosenTags = [];
-        let chosenTagIds = [];
-        for (var i = 0; i < e.target.options.length; i++) {
-            console.log("Option: ", e.target.options[i])
-            if (e.target.options[i].selected)
-            {
-                chosenTags.push(tags[i]);
-                chosenTagIds.push(tags[i].id);
-            }
-        }
+  };
 
-        setTagsToSave(chosenTags);
-        setTagIdsToSave(chosenTagIds);
-        console.log("chosenTags: ", chosenTags);
-        console.log("chosenTagIds: ", chosenTagIds);
-    }
+  return (
+    <>
+      <Button label="Add Tag" onClick={toggleOpen}/>
+      <MDBModal open={basicModal} onClose={() => setBasicModal(false)} tabIndex='-1'>
+        <MDBModalDialog>
+          <MDBModalContent>
+            <MDBModalHeader>
+              <MDBModalTitle>Add tags: {recipe.name}</MDBModalTitle>
+              <MDBBtn className='btn-close' color='none' onClick={toggleOpen}></MDBBtn>
+            </MDBModalHeader>
 
-    const updateRecipe = () => {
-        setActionMsg("Updating recipe with tags...");
+            <MDBModalBody>
 
-        if ((tagIdsToSave == null || tagIdsToSave.length == 0) && (recipeToTag.tags == null || recipeToTag.tags.length == 0)) {
-            setActionMsg("Please select one or more tags before clicking Update Tags.");
-            setTimeout(() => {
-                    setActionMsg(null);
-                }, 3000);    
-        } else {            
-            if ((tagIdsToSave == null || tagIdsToSave.length == 0) && recipeToTag.tags != null && recipeToTag.tags.length > 0) {
-                setActionMsg("Removing tags from recipe.");
-                setTagIdsToSave([]);
-            }
-            recipeService.updateTagsToRecipe(recipeToTag.id, tagIdsToSave)
-            .then((response) => {
-                if (tagIdsToSave.length > 0) {
-                    setActionMsg("Tags updated on recipe.");
-                    recipeToTag.tags = tagsToSave;
-                    console.log("recipeToTag: ", recipeToTag);
-                } else {
-                    setActionMsg("Tags removed from recipe.");
-                    recipeToTag.tags = [];
-                }
-            })
-            .catch((err) => {
-                setActionMsg("There was a problem connecting to the database.  Please try again later.");
-                console.log("Error: ", err.message);
-            });
-        }
-        
-    };
-
-    return (
-        <>
-            <Button label="Add Tag" onClick={toggleOpen} />
-            <MDBModal open={basicModal} onClose={() => setBasicModal(false)} tabIndex='-1'>
-                <MDBModalDialog>
-                    <MDBModalContent>
-                        <MDBModalHeader>
-                            <MDBModalTitle>Add tags: {recipeToTag.name}</MDBModalTitle>
-                            <MDBBtn className='btn-close' color='none' onClick={toggleOpen}></MDBBtn>
-                        </MDBModalHeader>
-
-                        <MDBModalBody>
-                            {actionMsg == null && tags != null &&
-                                <div>
-                                    <label>Select Multiple Tags</label>
-                                    <div>
-                                        <select name="tags" id="tags" size={tags.length} multiple onChange={e => handleTagSelect(e)}>
-                                        {
-                                            (() => {
-                                            let container = [];
-                                            let selected = false;
-                                            tags.forEach((tag, index) => {
-                                                for (var i = 0; i < recipeToTag.tags.length; i++) {
-                                                    selected = tag.id == recipeToTag.tags[i].id;
-                                                    if (selected) { break; }
-                                                }
-                                                container.push(
-                                                <option key={index} value={tag.id} title={tag.description} selected={selected}>{tag.name}</option>);
-                                            });
-                                            return container;
-                                            })()
-                                        }
-                                        </select>
-                                    </div>
-                                </div>
+              <MDBInput
+                label="Create new tag"
+                id="newTag"
+                type="text"
+                name="newTag"
+                onChange={e => setTagToCreate(e.target.value)}
+              />
+              <Button disabled={tagToCreate === null} label="Create Tag" onClick={createNewTag}/>
+              {tags.length > 0 &&
+                <div>
+                  <label>Select Multiple Tags</label>
+                  <div>
+                    <select
+                      name="tags"
+                      id="tags"
+                      size={tags.length}
+                      multiple
+                      onChange={e => handleTagSelect(e)}>
+                      {
+                        (() => {
+                          let container = [];
+                          let selected = false;
+                          tags.forEach((tag, index) => {
+                            for (var i = 0; i < recipe.tags.length; i++) {
+                              selected = tag.id == recipe.tags[i].id;
+                              if (selected) {
+                                break;
+                              }
                             }
-                            {actionMsg != null &&
-                                <div>{actionMsg}</div>
-                            }
-                       </MDBModalBody>
+                            container.push(
+                              <option key={index} value={tag.id} title={tag.description}
+                                      selected={selected}>{tag.name}</option>);
+                          });
+                          return container;
+                        })()
+                      }
+                    </select>
+                  </div>
+                </div>
+              }
+              {actionMsg != null &&
+                <div>{actionMsg}</div>
+              }
+            </MDBModalBody>
 
-                        <MDBModalFooter>
-                            <Button label="Close" onClick={closeWindow} />
-                            {actionMsg == null &&
-                                <Button label="Update Tags" onClick={updateRecipe}/>
-                            }      
-                        </MDBModalFooter>
-                    </MDBModalContent>
-                </MDBModalDialog>
-            </MDBModal>
-        </>
+            <MDBModalFooter>
+              <Button label="Close" onClick={closeWindow}/>
+              {actionMsg == null &&
+                <Button label="Update Tags" onClick={updateRecipe}/>
+              }
+            </MDBModalFooter>
+          </MDBModalContent>
+        </MDBModalDialog>
+      </MDBModal>
+    </>
   );
 }

--- a/plate-planner-react/src/components/RecipeCards.jsx
+++ b/plate-planner-react/src/components/RecipeCards.jsx
@@ -1,83 +1,86 @@
-import { useEffect, useState } from "react";
-import Button from "./Button";
-import RecipeSave from "./RecipeSave";
-import RecipeAddTag from "./RecipeAddTag";
 import AddRecipeToMealPlan from "./AddRecipeToMealPlan";
+import PropTypes from "prop-types";
+import RecipeAddTag from "./RecipeAddTag";
+import RecipeSave from "./RecipeSave";
+import { useState } from "react";
 
 function handleAddRecipeToMealPlan(recipeId) {
-    //open a modal, allow user to select meal plan or create new meal plan, call API
-    console.log("Recipe with ID (" + recipeId + ") saved to Meal Plan!" )
+  //open a modal, allow user to select meal plan or create new meal plan, call API
+  console.log("Recipe with ID (" + recipeId + ") saved to Meal Plan!")
 }
 
-function RecipeCards(props) {
-    const [recipes, setRecipes] = useState(props.recipes);
-    const [title, setTitle] = useState(props.title);
-    const [stateCounter, setStateCounter] = useState(0);
+// this will tell RecipeCards what props (and what the types are) so intellij doesn't freak out!
+RecipeCards.propTypes = {
+  recipes: PropTypes.array,
+  title: PropTypes.string
+};
 
-
-    if (recipes != undefined) {
-
-        return (
-         <div key="recipecards">
-            {recipes != null && title && 
-                <h1>{recipes.length} {title}</h1>
-            }
-            
-
-            {recipes.map((recipe) => (
-                <div key={recipe.id != null ? recipe.id : recipe.name} className="card">
-                    <h2 className='card-title'>{recipe.name}</h2>
-                    <p>{recipe.description}</p>
-                    <img src={recipe.imageURL} alt={recipe.name + " image"} className='card-img-top mx-auto d-block w-25'/>
-                    {recipe.tags != null && recipe.tags.length > 0 &&
-                    <div className="container">
-                        <div className="row justify-content-around">
-                        <div className="col"></div><div className="col"><div className="row justify-content-around">
-                            {recipe.tags.map((tag) => (
-                                <div className="col" key={tag.id != null ? tag.id : tag.name} style={{fontWeight: 600}}>
-                                &nbsp;{tag.name}&nbsp;
-                                </div>
-                            ))}
-                        </div></div><div className="col"></div>
+function RecipeCards({recipes = [], title}) {
+  const [stateCounter, setStateCounter] = useState(0);
+  if (recipes !== undefined) {
+    return (
+      <div key="recipecards">
+        {recipes != null && title &&
+          <h1>{recipes.length} {title}</h1>
+        }
+        {recipes.map((recipe) => (
+          <div key={recipe.id != null ? recipe.id : recipe.name} className="card">
+            <h2 className='card-title'>{recipe.name}</h2>
+            <p>{recipe.description}</p>
+            <img src={recipe.imageURL} alt={recipe.name + " image"} className='card-img-top mx-auto d-block w-25'/>
+            {recipe.tags != null && recipe.tags.length > 0 &&
+              <div className="container">
+                <div className="row justify-content-around">
+                  <div className="col"></div>
+                  <div className="col">
+                    <div className="row justify-content-around">
+                      {recipe.tags.map((tag) => (
+                        <div className="col" key={tag.id != null ? tag.id : tag.name} style={{fontWeight: 600}}>
+                          &nbsp;{tag.name}&nbsp;
                         </div>
+                      ))}
                     </div>
-                    }
-                    <h3>Ingredients:</h3>
-                    <ul className="list-unstyled">
-                        {recipe.recipeIngredients.map((ingredient) => (
-                            <li key={ingredient.id != null ? ingredient.id : ingredient.name}>
-                                {ingredient.quantity} {ingredient.unit} {ingredient.ingredient.name}
-                            </li>
-                        ))}
-                    </ul>
-                    <h3>Instructions:</h3>
-                    <p>{recipe.instructions}</p>
-                    <div className="container">
-                        <div className="row justify-content-around">
-                        {recipe.id == null &&
-                            <div className="col-4">
-                               <RecipeSave recipe={recipe} />
-                            </div>
-                        }
-                        {recipe.id != null &&
-                            <div className="col-4">
-                                <AddRecipeToMealPlan recipeId={recipe.id} />
-                            </div>
-                        }
-                        {recipe.id != null &&
-                            <div className="col-4">
-                                <RecipeAddTag recipe={recipe} setStateCounter={setStateCounter} counter={stateCounter} />
-                            </div>
-                        }
-                 </div>
-                    </div>
+                  </div>
+                  <div className="col"></div>
                 </div>
-            ))}
-        </div>
-        );
-    } else {
-        return (<div key="recipecards"></div>);
-    }
+              </div>
+            }
+            <h3>Ingredients:</h3>
+            <ul className="list-unstyled">
+              {recipe.recipeIngredients.map((ingredient) => (
+                <li key={ingredient.id != null ? ingredient.id : ingredient.name}>
+                  {ingredient.quantity} {ingredient.unit} {ingredient.ingredient.name}
+                </li>
+              ))}
+            </ul>
+            <h3>Instructions:</h3>
+            <p>{recipe.instructions}</p>
+            <div className="container">
+              <div className="row justify-content-around">
+                {recipe.id == null &&
+                  <div className="col-4">
+                    <RecipeSave recipe={recipe}/>
+                  </div>
+                }
+                {recipe.id != null &&
+                  <div className="col-4">
+                    <AddRecipeToMealPlan recipeId={recipe.id}/>
+                  </div>
+                }
+                {recipe.id != null &&
+                  <div className="col-4">
+                    <RecipeAddTag recipe={recipe} setStateCounter={setStateCounter} counter={stateCounter}/>
+                  </div>
+                }
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  } else {
+    return (<div key="recipecards"></div>);
+  }
 };
 
 export default RecipeCards;

--- a/plate-planner-react/src/components/RecipeCards.jsx
+++ b/plate-planner-react/src/components/RecipeCards.jsx
@@ -12,11 +12,12 @@ function handleAddRecipeToMealPlan(recipeId) {
 // this will tell RecipeCards what props (and what the types are) so intellij doesn't freak out!
 RecipeCards.propTypes = {
   recipes: PropTypes.array,
-  title: PropTypes.string
+  title: PropTypes.string,
+  stateCounter: PropTypes.number,
+  setStateCounter: PropTypes.func,
 };
 
-function RecipeCards({recipes = [], title}) {
-  const [stateCounter, setStateCounter] = useState(0);
+function RecipeCards({recipes = [], title, stateCounter, setStateCounter}) {
   if (recipes !== undefined) {
     return (
       <div key="recipecards">
@@ -69,7 +70,7 @@ function RecipeCards({recipes = [], title}) {
                 }
                 {recipe.id != null &&
                   <div className="col-4">
-                    <RecipeAddTag recipe={recipe} setStateCounter={setStateCounter} counter={stateCounter}/>
+                    <RecipeAddTag recipe={recipe} setStateCounter={setStateCounter} stateCounter={stateCounter}/>
                   </div>
                 }
               </div>

--- a/plate-planner-react/src/components/RecipeList.jsx
+++ b/plate-planner-react/src/components/RecipeList.jsx
@@ -1,57 +1,139 @@
-import { useEffect, useState } from "react";
+import {useCallback, useEffect, useState} from "react";
+
+import Cookies from 'js-cookie';
 import RecipeCards from './RecipeCards.jsx';
 import recipeService from "@/services/recipeService.js";
-import Cookies from 'js-cookie';
-
 
 const RecipeList = () => {
-    const [recipes, setRecipes] = useState([]);
-    const [filteredRecipes, setFilteredRecipes] = useState([]);
-    const [tags, setTags] = useState([]);
-    const [selectedTags, setSelectedTags] = useState([]);
-    const [loading, setLoading] = useState(true);
-    const [error, setError] = useState(null);
-    const userName = Cookies.get('username');
+  const [recipes, setRecipes] = useState([]);
+  const [filteredRecipes, setFilteredRecipes] = useState([]);
+  const [tags, setTags] = useState([]);
+  const [selectedTags, setSelectedTags] = useState([]);
+  const [showLoginNotice, setShowLoginNotice] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const userName = Cookies.get('username');
 
-    if (userName == null || userName.length == 0) {
-        return <p>Please login to see your saved recipes.</p>
+  // If the user is logged in, get all recipes saved by the user.  Otherwise, set the hook to show a login notice.
+  useEffect(() => {
+    if (userName !== null && userName !== undefined && userName.length > 0) {
+      recipeService.getAllByUser()
+        .then((response) => {
+          setRecipes(response.data);
+          setLoading(false);
+        })
+        .catch((err) => {
+          console.log("Error retrieving saved recipes: ", err.message);
+          setError("There was a problem retrieving your saved recipes.");
+          setLoading(false);
+        });
     } else {
-        useEffect(() => {
-            recipeService.getAllByUser()
-                .then((response) => {
-                    setRecipes(response.data);
-                    setLoading(false);
-                })
-                .catch((err) => {
-                    console.log("Error retrieving saved recipes: ", err.message);
-                    setError("There was a problem retrieving your saved recipes.");
-                    setLoading(false);
-                });
-        }, []);    
+      setShowLoginNotice(true);
+      setLoading(false);
     }
+  }, [userName]);
 
-    if (loading) {
-        return <p>Loading recipes...</p>;
-    }
+  // Extract unique tags from recipes
+  useEffect(() => {
+    // We'll just return if there are no recipes.
+    if (recipes.length === 0) return;
+    // This will make an array of all the tags and flatten it so we don't get any nasty nested stuff
+    const allTags = recipes.map(recipe => recipe.tags).flat();
+    // This makes a list of just unique names that we will use to filter the tags...
+    const uniqueTagNames = new Set(allTags.map(tag => tag.name));
+    // ...here
+    const uniqueTags = Array.from(uniqueTagNames)
+      .map(tagName => allTags.find(tag => tag.name === tagName));
+    setTags(uniqueTags);
+  }, [recipes]);
 
-    if (error) {
-        return <p>Error: {error}</p>;
-    }
-
-    function handleSaveRecipe(recipeId) {
-        //call API using axios here
-    }
-
-    function handleAddRecipeToMealPlan(recipeId) {
-        //open a modal, allow user to select meal plan or create new meal plan, call API
-    }
-
-    return (
-        <div>
-            <h2>Saved Recipes</h2>
-            <RecipeCards recipes={recipes} />
-        </div>
+  /**
+   * This little helper function will filter recipes based on selected tags.
+   */
+  const filterRecipesByTags = useCallback((recipesToFilter) => {
+    if (!selectedTags.length) return recipesToFilter;
+    return recipesToFilter.filter((recipe) =>
+      selectedTags.every((selectedTag) =>
+        recipe.tags.some((recipeTag) => recipeTag.name === selectedTag.name)
+      )
     );
+  }, [selectedTags]);
+
+  // Update filtered recipes whenever recipes or selected tags change
+  useEffect(() => {
+    setFilteredRecipes(filterRecipesByTags(recipes));
+  }, [recipes, filterRecipesByTags]);
+
+  /**
+   * This function toggles a tag in the selectedTags state.
+   * @param tag The tag to toggle.
+   */
+  const toggleTag = (tag) => {
+    setSelectedTags((prevSelectedTags) => {
+      const isSelected = prevSelectedTags.some((t) => t.name === tag.name);
+      return isSelected
+        ? prevSelectedTags.filter((t) => t.name !== tag.name)
+        : [...prevSelectedTags, tag];
+    });
+  };
+
+  // If the hook to show a login notice is set, display a message to the user to login.
+  if (showLoginNotice) {
+    return <p>Please login to see your saved recipes.</p>;
+  }
+
+  if (loading) {
+    return <p>Loading recipes...</p>;
+  }
+
+  if (error) {
+    return <p>Error: {error}</p>;
+  }
+
+  function handleSaveRecipe(recipeId) {
+    //call API using axios here
+  }
+
+  function handleAddRecipeToMealPlan(recipeId) {
+    //open a modal, allow user to select meal plan or create new meal plan, call API
+  }
+
+  return (
+    <div>
+      {tags.length > 0 && (
+        <>
+          <h2>Tags</h2>
+          <div>
+            {tags.map((tag) => (
+              <button
+                key={tag.name}
+                onClick={() => toggleTag(tag)}
+                style={{
+                  backgroundColor: selectedTags.some((t) => t.name === tag.name)
+                    ? "blue"
+                    : "gray",
+                  color: "white",
+                  margin: "5px",
+                  padding: "5px 10px",
+                  border: "none",
+                  borderRadius: "5px",
+                  cursor: "pointer",
+                }}
+              >
+                {tag.name}
+              </button>
+            ))}
+          </div>
+        </>
+      )}
+      <h2>Saved Recipes</h2>
+      {recipes.length === 0 ? (
+        <p>No recipes found.</p>
+      ) : (
+        <RecipeCards recipes={filteredRecipes}/>
+      )}
+    </div>
+  );
 };
 
 export default RecipeList;

--- a/plate-planner-react/src/components/RecipeList.jsx
+++ b/plate-planner-react/src/components/RecipeList.jsx
@@ -6,6 +6,9 @@ import Cookies from 'js-cookie';
 
 const RecipeList = () => {
     const [recipes, setRecipes] = useState([]);
+    const [filteredRecipes, setFilteredRecipes] = useState([]);
+    const [tags, setTags] = useState([]);
+    const [selectedTags, setSelectedTags] = useState([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(null);
     const userName = Cookies.get('username');
@@ -47,36 +50,6 @@ const RecipeList = () => {
         <div>
             <h2>Saved Recipes</h2>
             <RecipeCards recipes={recipes} />
-         {/*
-            <h1>Recipes</h1>
-            {recipes.map((recipe) => (
-                <div key={recipe.id} className="card">
-                    <h2 className='card-title'>{recipe.name}</h2>
-                    <p>{recipe.description}</p>
-                    <img src={recipe.imageURL} alt={recipe.name + " image"} className='card-img mx-auto d-block w-25'/>
-                    <h3>Ingredients:</h3>
-                    <ul className="list-unstyled">
-                        {recipe.recipeIngredients.map((ingredient) => (
-                            <li key={ingredient.id}>
-                                {ingredient.quantity} {ingredient.unit} {ingredient.ingredient.name}
-                            </li>
-                        ))}
-                    </ul>
-                    <h3>Instructions:</h3>
-                    <p>{recipe.instructions}</p>
-                    <div className="container">
-                        <div className="row justify-content-around">
-                            <div className="col-4">
-                                <Button label="Save Recipe" onClick={handleSaveRecipe(recipe.id)}/>
-                            </div>
-                            <div className="col-4">
-                                <Button label="Add to Meal Plan" onClick={handleAddRecipeToMealPlan(recipe.id)}/>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            ))}
-        */}
         </div>
     );
 };

--- a/plate-planner-react/src/components/RecipeList.jsx
+++ b/plate-planner-react/src/components/RecipeList.jsx
@@ -12,6 +12,7 @@ const RecipeList = () => {
   const [showLoginNotice, setShowLoginNotice] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  const [stateCounter, setStateCounter] = useState(0);
   const userName = Cookies.get('username');
 
   // If the user is logged in, get all recipes saved by the user.  Otherwise, set the hook to show a login notice.
@@ -32,6 +33,19 @@ const RecipeList = () => {
       setLoading(false);
     }
   }, [userName]);
+
+  // if stateCounter changes, reload the recipes (which reloads the tags).
+  useEffect(() => {
+    console.log('Reloading recipes because state counter changed.');
+    recipeService.getAllByUser()
+      .then((response) => {
+        setRecipes(response.data);
+      })
+      .catch((err) => {
+        console.log("Error retrieving saved recipes: ", err.message);
+        setError("There was a problem retrieving your saved recipes.");
+      });
+  }, [stateCounter]);
 
   // Extract unique tags from recipes
   useEffect(() => {
@@ -130,7 +144,7 @@ const RecipeList = () => {
       {recipes.length === 0 ? (
         <p>No recipes found.</p>
       ) : (
-        <RecipeCards recipes={filteredRecipes}/>
+        <RecipeCards recipes={filteredRecipes} stateCounter={stateCounter} setStateCounter={setStateCounter}/>
       )}
     </div>
   );


### PR DESCRIPTION
# Filter saved recipes by tag, add ad-hoc tags

I fixed my tag feature to use the new endpoints that don't need user data.

This pull request adds a couple of features:
- The ability to filter saved recipes by all the tags in all saved recipes
- The ability to add a tag from the tag selection modal

This pull request also fixes a few issues:
- In several places, props were immediately set to useState hooks which breaks reactivity.  I replaced this with just destructured props and prop definitions.
- I implemented stateCounter and setStateCounter properly so that child components have access to the setter and can alter the very top level stateCounter.
- Some of the useState hooks were initialized to null, but if they didn't get set, the frontend would crash when array methods would be called on them.  I changed these to initialize to empty arrays.