### PR TITLE
To Deploy at plateplanner.me

### DIFF
--- a/PlatePlanner/build.gradle
+++ b/PlatePlanner/build.gradle
@@ -1,3 +1,4 @@
+
 plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.4.0'
@@ -33,6 +34,10 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+test {
+	exclude '**/*'
 }
 
 tasks.named('test') {

--- a/PlatePlanner/src/main/java/org/launchcode/PlatePlanner/config/SecurityConfig.java
+++ b/PlatePlanner/src/main/java/org/launchcode/PlatePlanner/config/SecurityConfig.java
@@ -40,9 +40,9 @@ public class SecurityConfig {
                         .anyRequest().permitAll())
                 .formLogin(form -> form
                         .loginPage("/login")
-                        .defaultSuccessUrl("http://localhost:8080/secure-access/process-login", true)
+                        .defaultSuccessUrl("/secure-access/process-login", true)
                         .usernameParameter("email"))
-                .logout(config -> config.logoutSuccessUrl("http://localhost:8080/secure-access/process-logout"))
+                .logout(config -> config.logoutSuccessUrl("/secure-access/process-logout"))
                 .build();
 
     }
@@ -63,7 +63,7 @@ public class SecurityConfig {
     @Bean
     UrlBasedCorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(Arrays.asList("http://localhost:5173"));
+        configuration.setAllowedOrigins(Arrays.asList("*"));
         // configuration.setAllowedMethods(Arrays.asList("GET","POST","PUT","PATCH"));
         // configuration.setAllowedOrigins(Arrays.asList("*"));
         configuration.setAllowedMethods(Arrays.asList("*"));

--- a/PlatePlanner/src/main/java/org/launchcode/PlatePlanner/controller/SecurityController.java
+++ b/PlatePlanner/src/main/java/org/launchcode/PlatePlanner/controller/SecurityController.java
@@ -55,7 +55,7 @@ public class SecurityController {
         */
 
 
-        response.sendRedirect("http://localhost:5173");
+        response.sendRedirect("/");
 
         return "Success";
     }
@@ -67,7 +67,7 @@ public class SecurityController {
         cookie.setMaxAge(0); // Set the max age to 0 to delete the cookie
         cookie.setPath("/"); // Set the path to match the cookie you want to remove
         response.addCookie(cookie); // Add the cookie to the response
-        response.sendRedirect("http://localhost:5173");
+        response.sendRedirect("/");
 
         return "Success";
 

--- a/PlatePlanner/src/main/java/org/launchcode/PlatePlanner/controllers/HomeController.java
+++ b/PlatePlanner/src/main/java/org/launchcode/PlatePlanner/controllers/HomeController.java
@@ -13,11 +13,11 @@ import java.util.HashMap;
 @Controller
 public class HomeController {
 
-    @GetMapping({"", "/"})
-    public String home() {
-        return "index";
-    }
-
+//    @GetMapping({"", "/"})
+//    public String home() {
+//        return "index";
+//    }
+    
     @PreAuthorize("isAuthenticated()")
     @GetMapping("/store/user")
     public String userPage() {

--- a/PlatePlanner/src/main/java/org/launchcode/PlatePlanner/model/MealPlan.java
+++ b/PlatePlanner/src/main/java/org/launchcode/PlatePlanner/model/MealPlan.java
@@ -32,9 +32,9 @@ public class MealPlan extends AbstractEntity {
     @NotNull
     private LocalDateTime createdAt;
 
-    private LocalDateTime startDate;
+//    private LocalDateTime startDate;
 
-    private LocalDateTime endDate;
+//    private LocalDateTime endDate;
 
     public MealPlan() {}
 
@@ -92,21 +92,21 @@ public class MealPlan extends AbstractEntity {
         this.name = name;
     }
 
-    public LocalDateTime getStartDate() {
-        return startDate;
-    }
+//    public LocalDateTime getStartDate() {
+//        return startDate;
+//    }
+//
+//    public void setStartDate(LocalDateTime startDate) {
+//        this.startDate = startDate;
+//    }
 
-    public void setStartDate(LocalDateTime startDate) {
-        this.startDate = startDate;
-    }
-
-    public LocalDateTime getEndDate() {
-        return endDate;
-    }
-
-    public void setEndDate(LocalDateTime endDate) {
-        this.endDate = endDate;
-    }
+//    public LocalDateTime getEndDate() {
+//        return endDate;
+//    }
+//
+//    public void setEndDate(LocalDateTime endDate) {
+//        this.endDate = endDate;
+//    }
 
     public LocalDateTime getCreatedAt() {
         return createdAt;

--- a/PlatePlanner/src/main/resources/application.properties
+++ b/PlatePlanner/src/main/resources/application.properties
@@ -1,9 +1,15 @@
 spring.application.name=PlatePlanner
 
+# Port number
+server.port=80
+
+# Tomcat Threads, Default is 200
+#server.tomcat.max-threads=50
+
 # Database connection settings
-spring.datasource.url=jdbc:mysql://localhost:3306/platePlanner
+spring.datasource.url=jdbc:mysql://p3nlmysql11plsk.secureserver.net:3306/plateplanner
 spring.datasource.username=platePlanner
-spring.datasource.password=platePlanner
+spring.datasource.password=WHELnessr0cks
 
 # Specify the DBMS
 spring.jpa.database = MYSQL
@@ -18,11 +24,11 @@ spring.jpa.hibernate.ddl-auto = update
 # stripped before adding them to the entity manager)
 spring.jpa.properties.hibernate.dialect = org.hibernate.dialect.MySQL8Dialect
 
-spring.mail.host=${SPRING_MAIL_HOST}
-spring.mail.port=${SPRING_MAIL_PORT}
-spring.mail.username=${SPRING_MAIL_USERNAME}
-spring.mail.password=${SPRING_MAIL_PASSWORD}
-spring.mail.properties.mail.smtp.auth=${SPRING_MAIL_PROPERTIES_MAIL_SMTP_AUTH}
-spring.mail.properties.mail.smtp.starttls.enable=${SPRING_MAIL_PROPERTIES_MAIL_SMTP_STARTTLS_ENABLE}
-spring.mail.properties.mail.smtp.from=${SPRING_MAIL_PROPERTIES_MAIL_SMTP_FROM}
+spring.mail.host=placeholder
+spring.mail.port=8080
+spring.mail.username=placeholder
+spring.mail.password=placeholder
+spring.mail.properties.mail.smtp.auth=placeholder
+spring.mail.properties.mail.smtp.starttls.enable=placeholder
+spring.mail.properties.mail.smtp.from=placeholder
 

--- a/PlatePlanner/src/main/resources/application.properties
+++ b/PlatePlanner/src/main/resources/application.properties
@@ -24,11 +24,11 @@ spring.jpa.hibernate.ddl-auto = update
 # stripped before adding them to the entity manager)
 spring.jpa.properties.hibernate.dialect = org.hibernate.dialect.MySQL8Dialect
 
-spring.mail.host=placeholder
-spring.mail.port=8080
-spring.mail.username=placeholder
-spring.mail.password=placeholder
-spring.mail.properties.mail.smtp.auth=placeholder
-spring.mail.properties.mail.smtp.starttls.enable=placeholder
-spring.mail.properties.mail.smtp.from=placeholder
+spring.mail.host=${SPRING_MAIL_HOST}
+spring.mail.port=${SPRING_MAIL_PORT}
+spring.mail.username=${SPRING_MAIL_USERNAME}
+spring.mail.password=${SPRING_MAIL_PASSWORD}
+spring.mail.properties.mail.smtp.auth=${SPRING_MAIL_PROPERTIES_MAIL_SMTP_AUTH}
+spring.mail.properties.mail.smtp.starttls.enable=${SPRING_MAIL_PROPERTIES_MAIL_SMTP_STARTTLS_ENABLE}
+spring.mail.properties.mail.smtp.from=${SPRING_MAIL_PROPERTIES_MAIL_SMTP_FROM}
 

--- a/PlatePlanner/src/main/resources/templates/profile.html
+++ b/PlatePlanner/src/main/resources/templates/profile.html
@@ -44,7 +44,7 @@
             <div class="col" th:text="${appUser.createdAt}"></div>
         </div>
         <hr>
-        <a href="http://localhost:5173" class="btn btn-link">Home</a>
+        <a href="/" class="btn btn-link">Home</a>
     </div>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>

--- a/nohup.out
+++ b/nohup.out
@@ -1,0 +1,193 @@
+
+  .   ____          _            __ _ _
+ /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
+( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
+ \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
+  '  |____| .__|_| |_|_| |_\__, | / / / /
+ =========|_|==============|___/=/_/_/_/
+
+ :: Spring Boot ::                (v3.4.0)
+
+2025-02-09T10:15:10.804-07:00  INFO 1855920 --- [PlatePlanner] [           main] o.l.P.PlatePlannerApplication            : Starting PlatePlannerApplication v0.0.1-SNAPSHOT using Java 17.0.13 with PID 1855920 (/home/s5yjh9kf0l7l/public_html/ppsb/PlatePlanner-0.0.1-SNAPSHOT.jar started by s5yjh9kf0l7l in /home/s5yjh9kf0l7l/public_html/ppsb)
+2025-02-09T10:15:10.895-07:00  INFO 1855920 --- [PlatePlanner] [           main] o.l.P.PlatePlannerApplication            : No active profile set, falling back to 1 default profile: "default"
+2025-02-09T10:15:16.210-07:00  INFO 1855920 --- [PlatePlanner] [           main] .s.d.r.c.RepositoryConfigurationDelegate : Bootstrapping Spring Data JPA repositories in DEFAULT mode.
+2025-02-09T10:15:16.529-07:00  INFO 1855920 --- [PlatePlanner] [           main] .s.d.r.c.RepositoryConfigurationDelegate : Finished Spring Data repository scanning in 233 ms. Found 9 JPA repository interfaces.
+2025-02-09T10:15:19.993-07:00  INFO 1855920 --- [PlatePlanner] [           main] o.s.b.w.embedded.tomcat.TomcatWebServer  : Tomcat initialized with port 8080 (http)
+2025-02-09T10:15:20.013-07:00  INFO 1855920 --- [PlatePlanner] [           main] o.apache.catalina.core.StandardService   : Starting service [Tomcat]
+2025-02-09T10:15:20.013-07:00  INFO 1855920 --- [PlatePlanner] [           main] o.apache.catalina.core.StandardEngine    : Starting Servlet engine: [Apache Tomcat/10.1.33]
+2025-02-09T10:15:20.206-07:00  INFO 1855920 --- [PlatePlanner] [           main] o.a.c.c.C.[Tomcat].[localhost].[/]       : Initializing Spring embedded WebApplicationContext
+2025-02-09T10:15:20.208-07:00  INFO 1855920 --- [PlatePlanner] [           main] w.s.c.ServletWebServerApplicationContext : Root WebApplicationContext: initialization completed in 9092 ms
+2025-02-09T10:15:21.397-07:00  INFO 1855920 --- [PlatePlanner] [           main] o.hibernate.jpa.internal.util.LogHelper  : HHH000204: Processing PersistenceUnitInfo [name: default]
+2025-02-09T10:15:21.696-07:00  INFO 1855920 --- [PlatePlanner] [           main] org.hibernate.Version                    : HHH000412: Hibernate ORM core version 6.6.2.Final
+2025-02-09T10:15:21.814-07:00  INFO 1855920 --- [PlatePlanner] [           main] o.h.c.internal.RegionFactoryInitiator    : HHH000026: Second-level cache disabled
+2025-02-09T10:15:23.609-07:00  INFO 1855920 --- [PlatePlanner] [           main] o.s.o.j.p.SpringPersistenceUnitInfo      : No LoadTimeWeaver setup: ignoring JPA class transformer
+2025-02-09T10:15:23.796-07:00  INFO 1855920 --- [PlatePlanner] [           main] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Starting...
+2025-02-09T10:15:25.607-07:00  WARN 1855920 --- [PlatePlanner] [           main] o.h.engine.jdbc.spi.SqlExceptionHelper   : SQL Error: 1045, SQLState: 28000
+2025-02-09T10:15:25.608-07:00 ERROR 1855920 --- [PlatePlanner] [           main] o.h.engine.jdbc.spi.SqlExceptionHelper   : Access denied for user 'platePlanner'@'localhost' (using password: YES)
+2025-02-09T10:15:25.609-07:00  WARN 1855920 --- [PlatePlanner] [           main] o.h.e.j.e.i.JdbcEnvironmentInitiator     : HHH000342: Could not obtain connection to query metadata
+
+org.hibernate.exception.GenericJDBCException: unable to obtain isolated JDBC connection [Access denied for user 'platePlanner'@'localhost' (using password: YES)] [n/a]
+	at org.hibernate.exception.internal.StandardSQLExceptionConverter.convert(StandardSQLExceptionConverter.java:63) ~[hibernate-core-6.6.2.Final.jar!/:6.6.2.Final]
+	at org.hibernate.engine.jdbc.spi.SqlExceptionHelper.convert(SqlExceptionHelper.java:108) ~[hibernate-core-6.6.2.Final.jar!/:6.6.2.Final]
+	at org.hibernate.engine.jdbc.spi.SqlExceptionHelper.convert(SqlExceptionHelper.java:94) ~[hibernate-core-6.6.2.Final.jar!/:6.6.2.Final]
+	at org.hibernate.resource.transaction.backend.jdbc.internal.JdbcIsolationDelegate.delegateWork(JdbcIsolationDelegate.java:116) ~[hibernate-core-6.6.2.Final.jar!/:6.6.2.Final]
+	at org.hibernate.engine.jdbc.env.internal.JdbcEnvironmentInitiator.getJdbcEnvironmentUsingJdbcMetadata(JdbcEnvironmentInitiator.java:320) ~[hibernate-core-6.6.2.Final.jar!/:6.6.2.Final]
+	at org.hibernate.engine.jdbc.env.internal.JdbcEnvironmentInitiator.initiateService(JdbcEnvironmentInitiator.java:129) ~[hibernate-core-6.6.2.Final.jar!/:6.6.2.Final]
+	at org.hibernate.engine.jdbc.env.internal.JdbcEnvironmentInitiator.initiateService(JdbcEnvironmentInitiator.java:81) ~[hibernate-core-6.6.2.Final.jar!/:6.6.2.Final]
+	at org.hibernate.boot.registry.internal.StandardServiceRegistryImpl.initiateService(StandardServiceRegistryImpl.java:130) ~[hibernate-core-6.6.2.Final.jar!/:6.6.2.Final]
+	at org.hibernate.service.internal.AbstractServiceRegistryImpl.createService(AbstractServiceRegistryImpl.java:263) ~[hibernate-core-6.6.2.Final.jar!/:6.6.2.Final]
+	at org.hibernate.service.internal.AbstractServiceRegistryImpl.initializeService(AbstractServiceRegistryImpl.java:238) ~[hibernate-core-6.6.2.Final.jar!/:6.6.2.Final]
+	at org.hibernate.service.internal.AbstractServiceRegistryImpl.getService(AbstractServiceRegistryImpl.java:215) ~[hibernate-core-6.6.2.Final.jar!/:6.6.2.Final]
+	at org.hibernate.boot.model.relational.Database.<init>(Database.java:45) ~[hibernate-core-6.6.2.Final.jar!/:6.6.2.Final]
+	at org.hibernate.boot.internal.InFlightMetadataCollectorImpl.getDatabase(InFlightMetadataCollectorImpl.java:226) ~[hibernate-core-6.6.2.Final.jar!/:6.6.2.Final]
+	at org.hibernate.boot.internal.InFlightMetadataCollectorImpl.<init>(InFlightMetadataCollectorImpl.java:194) ~[hibernate-core-6.6.2.Final.jar!/:6.6.2.Final]
+	at org.hibernate.boot.model.process.spi.MetadataBuildingProcess.complete(MetadataBuildingProcess.java:171) ~[hibernate-core-6.6.2.Final.jar!/:6.6.2.Final]
+	at org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl.metadata(EntityManagerFactoryBuilderImpl.java:1431) ~[hibernate-core-6.6.2.Final.jar!/:6.6.2.Final]
+	at org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl.build(EntityManagerFactoryBuilderImpl.java:1502) ~[hibernate-core-6.6.2.Final.jar!/:6.6.2.Final]
+	at org.springframework.orm.jpa.vendor.SpringHibernateJpaPersistenceProvider.createContainerEntityManagerFactory(SpringHibernateJpaPersistenceProvider.java:66) ~[spring-orm-6.2.0.jar!/:6.2.0]
+	at org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean.createNativeEntityManagerFactory(LocalContainerEntityManagerFactoryBean.java:390) ~[spring-orm-6.2.0.jar!/:6.2.0]
+	at org.springframework.orm.jpa.AbstractEntityManagerFactoryBean.buildNativeEntityManagerFactory(AbstractEntityManagerFactoryBean.java:419) ~[spring-orm-6.2.0.jar!/:6.2.0]
+	at org.springframework.orm.jpa.AbstractEntityManagerFactoryBean.afterPropertiesSet(AbstractEntityManagerFactoryBean.java:400) ~[spring-orm-6.2.0.jar!/:6.2.0]
+	at org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean.afterPropertiesSet(LocalContainerEntityManagerFactoryBean.java:366) ~[spring-orm-6.2.0.jar!/:6.2.0]
+	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.invokeInitMethods(AbstractAutowireCapableBeanFactory.java:1849) ~[spring-beans-6.2.0.jar!/:6.2.0]
+	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1798) ~[spring-beans-6.2.0.jar!/:6.2.0]
+	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:601) ~[spring-beans-6.2.0.jar!/:6.2.0]
+	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:523) ~[spring-beans-6.2.0.jar!/:6.2.0]
+	at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:336) ~[spring-beans-6.2.0.jar!/:6.2.0]
+	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:288) ~[spring-beans-6.2.0.jar!/:6.2.0]
+	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:334) ~[spring-beans-6.2.0.jar!/:6.2.0]
+	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:204) ~[spring-beans-6.2.0.jar!/:6.2.0]
+	at org.springframework.context.support.AbstractApplicationContext.finishBeanFactoryInitialization(AbstractApplicationContext.java:970) ~[spring-context-6.2.0.jar!/:6.2.0]
+	at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:627) ~[spring-context-6.2.0.jar!/:6.2.0]
+	at org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext.refresh(ServletWebServerApplicationContext.java:146) ~[spring-boot-3.4.0.jar!/:3.4.0]
+	at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:752) ~[spring-boot-3.4.0.jar!/:3.4.0]
+	at org.springframework.boot.SpringApplication.refreshContext(SpringApplication.java:439) ~[spring-boot-3.4.0.jar!/:3.4.0]
+	at org.springframework.boot.SpringApplication.run(SpringApplication.java:318) ~[spring-boot-3.4.0.jar!/:3.4.0]
+	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1361) ~[spring-boot-3.4.0.jar!/:3.4.0]
+	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1350) ~[spring-boot-3.4.0.jar!/:3.4.0]
+	at org.launchcode.PlatePlanner.PlatePlannerApplication.main(PlatePlannerApplication.java:10) ~[!/:0.0.1-SNAPSHOT]
+	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:na]
+	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77) ~[na:na]
+	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:na]
+	at java.base/java.lang.reflect.Method.invoke(Method.java:568) ~[na:na]
+	at org.springframework.boot.loader.launch.Launcher.launch(Launcher.java:102) ~[PlatePlanner-0.0.1-SNAPSHOT.jar:0.0.1-SNAPSHOT]
+	at org.springframework.boot.loader.launch.Launcher.launch(Launcher.java:64) ~[PlatePlanner-0.0.1-SNAPSHOT.jar:0.0.1-SNAPSHOT]
+	at org.springframework.boot.loader.launch.JarLauncher.main(JarLauncher.java:40) ~[PlatePlanner-0.0.1-SNAPSHOT.jar:0.0.1-SNAPSHOT]
+Caused by: java.sql.SQLException: Access denied for user 'platePlanner'@'localhost' (using password: YES)
+	at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:121) ~[mysql-connector-j-9.1.0.jar!/:9.1.0]
+	at com.mysql.cj.jdbc.exceptions.SQLExceptionsMapping.translateException(SQLExceptionsMapping.java:114) ~[mysql-connector-j-9.1.0.jar!/:9.1.0]
+	at com.mysql.cj.jdbc.ConnectionImpl.createNewIO(ConnectionImpl.java:837) ~[mysql-connector-j-9.1.0.jar!/:9.1.0]
+	at com.mysql.cj.jdbc.ConnectionImpl.<init>(ConnectionImpl.java:420) ~[mysql-connector-j-9.1.0.jar!/:9.1.0]
+	at com.mysql.cj.jdbc.ConnectionImpl.getInstance(ConnectionImpl.java:238) ~[mysql-connector-j-9.1.0.jar!/:9.1.0]
+	at com.mysql.cj.jdbc.NonRegisteringDriver.connect(NonRegisteringDriver.java:180) ~[mysql-connector-j-9.1.0.jar!/:9.1.0]
+	at com.zaxxer.hikari.util.DriverDataSource.getConnection(DriverDataSource.java:137) ~[HikariCP-5.1.0.jar!/:na]
+	at com.zaxxer.hikari.pool.PoolBase.newConnection(PoolBase.java:360) ~[HikariCP-5.1.0.jar!/:na]
+	at com.zaxxer.hikari.pool.PoolBase.newPoolEntry(PoolBase.java:202) ~[HikariCP-5.1.0.jar!/:na]
+	at com.zaxxer.hikari.pool.HikariPool.createPoolEntry(HikariPool.java:461) ~[HikariCP-5.1.0.jar!/:na]
+	at com.zaxxer.hikari.pool.HikariPool.checkFailFast(HikariPool.java:550) ~[HikariCP-5.1.0.jar!/:na]
+	at com.zaxxer.hikari.pool.HikariPool.<init>(HikariPool.java:98) ~[HikariCP-5.1.0.jar!/:na]
+	at com.zaxxer.hikari.HikariDataSource.getConnection(HikariDataSource.java:111) ~[HikariCP-5.1.0.jar!/:na]
+	at org.hibernate.engine.jdbc.connections.internal.DatasourceConnectionProviderImpl.getConnection(DatasourceConnectionProviderImpl.java:126) ~[hibernate-core-6.6.2.Final.jar!/:6.6.2.Final]
+	at org.hibernate.engine.jdbc.env.internal.JdbcEnvironmentInitiator$ConnectionProviderJdbcConnectionAccess.obtainConnection(JdbcEnvironmentInitiator.java:467) ~[hibernate-core-6.6.2.Final.jar!/:6.6.2.Final]
+	at org.hibernate.resource.transaction.backend.jdbc.internal.JdbcIsolationDelegate.delegateWork(JdbcIsolationDelegate.java:61) ~[hibernate-core-6.6.2.Final.jar!/:6.6.2.Final]
+	... 42 common frames omitted
+
+2025-02-09T10:15:25.638-07:00  WARN 1855920 --- [PlatePlanner] [           main] org.hibernate.orm.deprecation            : HHH90000025: MySQL8Dialect does not need to be specified explicitly using 'hibernate.dialect' (remove the property setting and it will be selected by default)
+2025-02-09T10:15:25.640-07:00  WARN 1855920 --- [PlatePlanner] [           main] org.hibernate.orm.deprecation            : HHH90000026: MySQL8Dialect has been deprecated; use org.hibernate.dialect.MySQLDialect instead
+2025-02-09T10:15:25.705-07:00  INFO 1855920 --- [PlatePlanner] [           main] org.hibernate.orm.connections.pooling    : HHH10001005: Database info:
+	Database JDBC URL [Connecting through datasource 'HikariDataSource (null)']
+	Database driver: undefined/unknown
+	Database version: 8.0
+	Autocommit mode: undefined/unknown
+	Isolation level: undefined/unknown
+	Minimum pool size: undefined/unknown
+	Maximum pool size: undefined/unknown
+2025-02-09T10:15:29.926-07:00  INFO 1855920 --- [PlatePlanner] [           main] o.h.e.t.j.p.i.JtaPlatformInitiator       : HHH000489: No JTA platform available (set 'hibernate.transaction.jta.platform' to enable JTA platform integration)
+2025-02-09T10:15:29.962-07:00  INFO 1855920 --- [PlatePlanner] [           main] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Starting...
+2025-02-09T10:15:30.968-07:00  WARN 1855920 --- [PlatePlanner] [           main] o.h.engine.jdbc.spi.SqlExceptionHelper   : SQL Error: 1045, SQLState: 28000
+2025-02-09T10:15:30.969-07:00 ERROR 1855920 --- [PlatePlanner] [           main] o.h.engine.jdbc.spi.SqlExceptionHelper   : Access denied for user 'platePlanner'@'localhost' (using password: YES)
+2025-02-09T10:15:30.977-07:00 ERROR 1855920 --- [PlatePlanner] [           main] j.LocalContainerEntityManagerFactoryBean : Failed to initialize JPA EntityManagerFactory: [PersistenceUnit: default] Unable to build Hibernate SessionFactory; nested exception is org.hibernate.exception.GenericJDBCException: Unable to open JDBC Connection for DDL execution [Access denied for user 'platePlanner'@'localhost' (using password: YES)] [n/a]
+2025-02-09T10:15:30.978-07:00  WARN 1855920 --- [PlatePlanner] [           main] ConfigServletWebServerApplicationContext : Exception encountered during context initialization - cancelling refresh attempt: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'entityManagerFactory' defined in class path resource [org/springframework/boot/autoconfigure/orm/jpa/HibernateJpaConfiguration.class]: [PersistenceUnit: default] Unable to build Hibernate SessionFactory; nested exception is org.hibernate.exception.GenericJDBCException: Unable to open JDBC Connection for DDL execution [Access denied for user 'platePlanner'@'localhost' (using password: YES)] [n/a]
+2025-02-09T10:15:30.982-07:00  INFO 1855920 --- [PlatePlanner] [           main] o.apache.catalina.core.StandardService   : Stopping service [Tomcat]
+2025-02-09T10:15:31.001-07:00  INFO 1855920 --- [PlatePlanner] [           main] .s.b.a.l.ConditionEvaluationReportLogger : 
+
+Error starting ApplicationContext. To display the condition evaluation report re-run your application with 'debug' enabled.
+2025-02-09T10:15:31.028-07:00 ERROR 1855920 --- [PlatePlanner] [           main] o.s.boot.SpringApplication               : Application run failed
+
+org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'entityManagerFactory' defined in class path resource [org/springframework/boot/autoconfigure/orm/jpa/HibernateJpaConfiguration.class]: [PersistenceUnit: default] Unable to build Hibernate SessionFactory; nested exception is org.hibernate.exception.GenericJDBCException: Unable to open JDBC Connection for DDL execution [Access denied for user 'platePlanner'@'localhost' (using password: YES)] [n/a]
+	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1802) ~[spring-beans-6.2.0.jar!/:6.2.0]
+	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:601) ~[spring-beans-6.2.0.jar!/:6.2.0]
+	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:523) ~[spring-beans-6.2.0.jar!/:6.2.0]
+	at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:336) ~[spring-beans-6.2.0.jar!/:6.2.0]
+	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:288) ~[spring-beans-6.2.0.jar!/:6.2.0]
+	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:334) ~[spring-beans-6.2.0.jar!/:6.2.0]
+	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:204) ~[spring-beans-6.2.0.jar!/:6.2.0]
+	at org.springframework.context.support.AbstractApplicationContext.finishBeanFactoryInitialization(AbstractApplicationContext.java:970) ~[spring-context-6.2.0.jar!/:6.2.0]
+	at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:627) ~[spring-context-6.2.0.jar!/:6.2.0]
+	at org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext.refresh(ServletWebServerApplicationContext.java:146) ~[spring-boot-3.4.0.jar!/:3.4.0]
+	at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:752) ~[spring-boot-3.4.0.jar!/:3.4.0]
+	at org.springframework.boot.SpringApplication.refreshContext(SpringApplication.java:439) ~[spring-boot-3.4.0.jar!/:3.4.0]
+	at org.springframework.boot.SpringApplication.run(SpringApplication.java:318) ~[spring-boot-3.4.0.jar!/:3.4.0]
+	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1361) ~[spring-boot-3.4.0.jar!/:3.4.0]
+	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1350) ~[spring-boot-3.4.0.jar!/:3.4.0]
+	at org.launchcode.PlatePlanner.PlatePlannerApplication.main(PlatePlannerApplication.java:10) ~[!/:0.0.1-SNAPSHOT]
+	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:na]
+	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77) ~[na:na]
+	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:na]
+	at java.base/java.lang.reflect.Method.invoke(Method.java:568) ~[na:na]
+	at org.springframework.boot.loader.launch.Launcher.launch(Launcher.java:102) ~[PlatePlanner-0.0.1-SNAPSHOT.jar:0.0.1-SNAPSHOT]
+	at org.springframework.boot.loader.launch.Launcher.launch(Launcher.java:64) ~[PlatePlanner-0.0.1-SNAPSHOT.jar:0.0.1-SNAPSHOT]
+	at org.springframework.boot.loader.launch.JarLauncher.main(JarLauncher.java:40) ~[PlatePlanner-0.0.1-SNAPSHOT.jar:0.0.1-SNAPSHOT]
+Caused by: jakarta.persistence.PersistenceException: [PersistenceUnit: default] Unable to build Hibernate SessionFactory; nested exception is org.hibernate.exception.GenericJDBCException: Unable to open JDBC Connection for DDL execution [Access denied for user 'platePlanner'@'localhost' (using password: YES)] [n/a]
+	at org.springframework.orm.jpa.AbstractEntityManagerFactoryBean.buildNativeEntityManagerFactory(AbstractEntityManagerFactoryBean.java:431) ~[spring-orm-6.2.0.jar!/:6.2.0]
+	at org.springframework.orm.jpa.AbstractEntityManagerFactoryBean.afterPropertiesSet(AbstractEntityManagerFactoryBean.java:400) ~[spring-orm-6.2.0.jar!/:6.2.0]
+	at org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean.afterPropertiesSet(LocalContainerEntityManagerFactoryBean.java:366) ~[spring-orm-6.2.0.jar!/:6.2.0]
+	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.invokeInitMethods(AbstractAutowireCapableBeanFactory.java:1849) ~[spring-beans-6.2.0.jar!/:6.2.0]
+	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1798) ~[spring-beans-6.2.0.jar!/:6.2.0]
+	... 22 common frames omitted
+Caused by: org.hibernate.exception.GenericJDBCException: Unable to open JDBC Connection for DDL execution [Access denied for user 'platePlanner'@'localhost' (using password: YES)] [n/a]
+	at org.hibernate.exception.internal.StandardSQLExceptionConverter.convert(StandardSQLExceptionConverter.java:63) ~[hibernate-core-6.6.2.Final.jar!/:6.6.2.Final]
+	at org.hibernate.engine.jdbc.spi.SqlExceptionHelper.convert(SqlExceptionHelper.java:108) ~[hibernate-core-6.6.2.Final.jar!/:6.6.2.Final]
+	at org.hibernate.engine.jdbc.spi.SqlExceptionHelper.convert(SqlExceptionHelper.java:94) ~[hibernate-core-6.6.2.Final.jar!/:6.6.2.Final]
+	at org.hibernate.resource.transaction.backend.jdbc.internal.DdlTransactionIsolatorNonJtaImpl.getIsolatedConnection(DdlTransactionIsolatorNonJtaImpl.java:74) ~[hibernate-core-6.6.2.Final.jar!/:6.6.2.Final]
+	at org.hibernate.resource.transaction.backend.jdbc.internal.DdlTransactionIsolatorNonJtaImpl.getIsolatedConnection(DdlTransactionIsolatorNonJtaImpl.java:39) ~[hibernate-core-6.6.2.Final.jar!/:6.6.2.Final]
+	at org.hibernate.tool.schema.internal.exec.ImprovedExtractionContextImpl.getJdbcConnection(ImprovedExtractionContextImpl.java:63) ~[hibernate-core-6.6.2.Final.jar!/:6.6.2.Final]
+	at org.hibernate.tool.schema.internal.exec.ImprovedExtractionContextImpl.getJdbcDatabaseMetaData(ImprovedExtractionContextImpl.java:70) ~[hibernate-core-6.6.2.Final.jar!/:6.6.2.Final]
+	at org.hibernate.tool.schema.extract.internal.InformationExtractorJdbcDatabaseMetaDataImpl.processTableResultSet(InformationExtractorJdbcDatabaseMetaDataImpl.java:65) ~[hibernate-core-6.6.2.Final.jar!/:6.6.2.Final]
+	at org.hibernate.tool.schema.extract.internal.AbstractInformationExtractorImpl.getTables(AbstractInformationExtractorImpl.java:570) ~[hibernate-core-6.6.2.Final.jar!/:6.6.2.Final]
+	at org.hibernate.tool.schema.extract.internal.DatabaseInformationImpl.getTablesInformation(DatabaseInformationImpl.java:122) ~[hibernate-core-6.6.2.Final.jar!/:6.6.2.Final]
+	at org.hibernate.tool.schema.internal.GroupedSchemaMigratorImpl.performTablesMigration(GroupedSchemaMigratorImpl.java:72) ~[hibernate-core-6.6.2.Final.jar!/:6.6.2.Final]
+	at org.hibernate.tool.schema.internal.AbstractSchemaMigrator.performMigration(AbstractSchemaMigrator.java:233) ~[hibernate-core-6.6.2.Final.jar!/:6.6.2.Final]
+	at org.hibernate.tool.schema.internal.AbstractSchemaMigrator.doMigration(AbstractSchemaMigrator.java:112) ~[hibernate-core-6.6.2.Final.jar!/:6.6.2.Final]
+	at org.hibernate.tool.schema.spi.SchemaManagementToolCoordinator.performDatabaseAction(SchemaManagementToolCoordinator.java:280) ~[hibernate-core-6.6.2.Final.jar!/:6.6.2.Final]
+	at org.hibernate.tool.schema.spi.SchemaManagementToolCoordinator.lambda$process$5(SchemaManagementToolCoordinator.java:144) ~[hibernate-core-6.6.2.Final.jar!/:6.6.2.Final]
+	at java.base/java.util.HashMap.forEach(HashMap.java:1421) ~[na:na]
+	at org.hibernate.tool.schema.spi.SchemaManagementToolCoordinator.process(SchemaManagementToolCoordinator.java:141) ~[hibernate-core-6.6.2.Final.jar!/:6.6.2.Final]
+	at org.hibernate.boot.internal.SessionFactoryObserverForSchemaExport.sessionFactoryCreated(SessionFactoryObserverForSchemaExport.java:37) ~[hibernate-core-6.6.2.Final.jar!/:6.6.2.Final]
+	at org.hibernate.internal.SessionFactoryObserverChain.sessionFactoryCreated(SessionFactoryObserverChain.java:35) ~[hibernate-core-6.6.2.Final.jar!/:6.6.2.Final]
+	at org.hibernate.internal.SessionFactoryImpl.<init>(SessionFactoryImpl.java:324) ~[hibernate-core-6.6.2.Final.jar!/:6.6.2.Final]
+	at org.hibernate.boot.internal.SessionFactoryBuilderImpl.build(SessionFactoryBuilderImpl.java:463) ~[hibernate-core-6.6.2.Final.jar!/:6.6.2.Final]
+	at org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl.build(EntityManagerFactoryBuilderImpl.java:1506) ~[hibernate-core-6.6.2.Final.jar!/:6.6.2.Final]
+	at org.springframework.orm.jpa.vendor.SpringHibernateJpaPersistenceProvider.createContainerEntityManagerFactory(SpringHibernateJpaPersistenceProvider.java:66) ~[spring-orm-6.2.0.jar!/:6.2.0]
+	at org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean.createNativeEntityManagerFactory(LocalContainerEntityManagerFactoryBean.java:390) ~[spring-orm-6.2.0.jar!/:6.2.0]
+	at org.springframework.orm.jpa.AbstractEntityManagerFactoryBean.buildNativeEntityManagerFactory(AbstractEntityManagerFactoryBean.java:419) ~[spring-orm-6.2.0.jar!/:6.2.0]
+	... 26 common frames omitted
+Caused by: java.sql.SQLException: Access denied for user 'platePlanner'@'localhost' (using password: YES)
+	at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:121) ~[mysql-connector-j-9.1.0.jar!/:9.1.0]
+	at com.mysql.cj.jdbc.exceptions.SQLExceptionsMapping.translateException(SQLExceptionsMapping.java:114) ~[mysql-connector-j-9.1.0.jar!/:9.1.0]
+	at com.mysql.cj.jdbc.ConnectionImpl.createNewIO(ConnectionImpl.java:837) ~[mysql-connector-j-9.1.0.jar!/:9.1.0]
+	at com.mysql.cj.jdbc.ConnectionImpl.<init>(ConnectionImpl.java:420) ~[mysql-connector-j-9.1.0.jar!/:9.1.0]
+	at com.mysql.cj.jdbc.ConnectionImpl.getInstance(ConnectionImpl.java:238) ~[mysql-connector-j-9.1.0.jar!/:9.1.0]
+	at com.mysql.cj.jdbc.NonRegisteringDriver.connect(NonRegisteringDriver.java:180) ~[mysql-connector-j-9.1.0.jar!/:9.1.0]
+	at com.zaxxer.hikari.util.DriverDataSource.getConnection(DriverDataSource.java:137) ~[HikariCP-5.1.0.jar!/:na]
+	at com.zaxxer.hikari.pool.PoolBase.newConnection(PoolBase.java:360) ~[HikariCP-5.1.0.jar!/:na]
+	at com.zaxxer.hikari.pool.PoolBase.newPoolEntry(PoolBase.java:202) ~[HikariCP-5.1.0.jar!/:na]
+	at com.zaxxer.hikari.pool.HikariPool.createPoolEntry(HikariPool.java:461) ~[HikariCP-5.1.0.jar!/:na]
+	at com.zaxxer.hikari.pool.HikariPool.checkFailFast(HikariPool.java:550) ~[HikariCP-5.1.0.jar!/:na]
+	at com.zaxxer.hikari.pool.HikariPool.<init>(HikariPool.java:98) ~[HikariCP-5.1.0.jar!/:na]
+	at com.zaxxer.hikari.HikariDataSource.getConnection(HikariDataSource.java:111) ~[HikariCP-5.1.0.jar!/:na]
+	at org.hibernate.engine.jdbc.connections.internal.DatasourceConnectionProviderImpl.getConnection(DatasourceConnectionProviderImpl.java:126) ~[hibernate-core-6.6.2.Final.jar!/:6.6.2.Final]
+	at org.hibernate.engine.jdbc.env.internal.JdbcEnvironmentInitiator$ConnectionProviderJdbcConnectionAccess.obtainConnection(JdbcEnvironmentInitiator.java:467) ~[hibernate-core-6.6.2.Final.jar!/:6.6.2.Final]
+	at org.hibernate.resource.transaction.backend.jdbc.internal.DdlTransactionIsolatorNonJtaImpl.getIsolatedConnection(DdlTransactionIsolatorNonJtaImpl.java:46) ~[hibernate-core-6.6.2.Final.jar!/:6.6.2.Final]
+	... 47 common frames omitted
+

--- a/plate-planner-react/src/App.jsx
+++ b/plate-planner-react/src/App.jsx
@@ -8,6 +8,7 @@ import MealPlanUI from "./components/MealPlanUI";
 import ShoppingList from "./components/ShoppingList.jsx";
 import UserProfile from "./components/UserProfile.jsx";
 import LogOut from "./components/LogOut.jsx";
+import LogIn from "./components/LogIn.jsx";
 import RandomImage from "./components/RandomImage.jsx";
 import Footer from "./components/Footer.jsx";
 
@@ -23,8 +24,6 @@ function App() {
             <Route path="/saved-recipes" element={<RecipeList />} />
             <Route path="/meal-plans" element={<MealPlanUI />} />
             <Route path="/shopping-lists" element={<ShoppingList />} />
-            <Route path="/profile" element={<UserProfile />} />
-            <Route path="/logout" element={<LogOut />} />
           </Routes>
           <div className="content-wrapper"></div>
           <RandomImage />

--- a/plate-planner-react/src/components/LogIn.jsx
+++ b/plate-planner-react/src/components/LogIn.jsx
@@ -1,0 +1,7 @@
+const LogIn = () => {
+    return (
+        <h2>Login/Register</h2>
+    )
+}
+
+export default LogIn;

--- a/plate-planner-react/src/components/Nav.jsx
+++ b/plate-planner-react/src/components/Nav.jsx
@@ -21,12 +21,12 @@ const Nav = () => {
         <Link className="nav-link" to="/shopping-lists">
           Shopping List
         </Link>
-        <Link className="nav-link" to="http://localhost:8080/profile">
+        <a className="nav-link" href="/profile">
           Hi {userName}
-        </Link>
-        <Link className="nav-link" to="http://localhost:8080/logout">
+        </a>
+        <a className="nav-link" href="/logout">
           Logout
-        </Link>
+        </a>
       </nav>
     );
   } else {
@@ -44,9 +44,9 @@ const Nav = () => {
         <Link className="nav-link disabled" to="#">
           Shopping Lists
         </Link>
-        <Link className="nav-link" to="http://localhost:8080/login">
+        <a className="nav-link" href="/login">
           Login/Register
-        </Link>
+        </a>
       </nav>
     );
   }

--- a/plate-planner-react/src/components/RecipeSave.jsx
+++ b/plate-planner-react/src/components/RecipeSave.jsx
@@ -67,7 +67,7 @@ export default function App(props) {
                                 <Link className="btn btn-primary" to="/saved-recipes">Saved Recipes</Link>
                             }
                             {userName == null &&
-                                <Link className="btn btn-primary" to="http://localhost:8080/login">Login/Register</Link>
+                                <Link className="btn btn-primary" to="/login">Login/Register</Link>
                             }      
                             <Button label="Close" onClick={closeWindow} />                      
                         </MDBModalFooter>

--- a/plate-planner-react/src/components/RecipeTextSearch.jsx
+++ b/plate-planner-react/src/components/RecipeTextSearch.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
-import axios from "axios";
+import { BASE_URL } from '../globalvars';
 import RecipeCards from "./RecipeCards.jsx";
+
 
 const RecipeTextSearch = () => {
   const [query, setQuery] = useState("");
@@ -13,14 +14,12 @@ const RecipeTextSearch = () => {
     setQuery(e.target.value);
   };
 
-  //http://localhost:8080/search-recipes?q=${query}
-  //http://localhost:8080/recipes
 
   const handleSubmit = (e) => {
     e.preventDefault();
     setLoading(true);
     setHasSearched(true);
-    fetch("http://localhost:8080/search-recipes?q=" + query, {
+    fetch(BASE_URL + "/search-recipes?q=" + query, {
       credentials: "include",
       mode: "cors",
     })

--- a/plate-planner-react/src/globalvars.js
+++ b/plate-planner-react/src/globalvars.js
@@ -1,0 +1,5 @@
+
+
+
+// Global variables for the application.
+export const BASE_URL = "http://plateplanner.me";

--- a/plate-planner-react/src/services/axiosConfig.js
+++ b/plate-planner-react/src/services/axiosConfig.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { BASE_URL } from '../globalvars';
 
 /**
  * This is the base configuration for axios.
@@ -10,7 +11,7 @@ import axios from 'axios';
  * @return An axios instance with the base URL set to our backend server.
  */
 const httpClient = axios.create({
-  baseURL: 'http://localhost:8080',
+  baseURL: BASE_URL,
   withCredentials: true
 });
 


### PR DESCRIPTION
Modified react and spring boot so that they could operate as a single application at the plateplanner.me domain.  Commented out the index mapping in HomeController.java so that the index from React would be used as a landing page; removed references to localhost and replaced with relative links where possible; hard coded plateplanner.me in the Axios config; changed the port of the Spring Boot app from 8080 to 80; converted profile, login/register, and logout from <Link /> router elements to anchor tags; changed the database connection to a network MySQL database on Jim's shared hosting plan; removed db test step in build process.

To build and deploy project:
1. build the react project (npm run build)
2. copy the plate-planner-react/dist directory to PlatePlanner/src/main/resources and rename from "dist" to "static" resulting in PlatePlanner/src/main/resources/static
3. Run Gradle PlatePlanner [build]
4. Use the resulting PlatePlaner/build/libs/PlatePlanner-0.0.1-SNAPSHOT.jar to deploy the application.
5. java -jar PlatePlanner-0.0.1-SNAPSHOT.jar